### PR TITLE
Added support for URLs in strings' content

### DIFF
--- a/Sources/airstrings/PushCommand.swift
+++ b/Sources/airstrings/PushCommand.swift
@@ -45,11 +45,18 @@ class PushCommand: Command {
 
 			// Extract comment
 			var comment: String?
-			if let commentRange = line.range(of: "//") {
+			if let commentRange = line.range(of: "\";\\s*//", options: .regularExpression)  {
 				comment = line.suffix(from: commentRange.upperBound).trimmingCharacters(in: .whitespaces)
-				line = line.prefix(upTo: commentRange.lowerBound)
 			} else {
 				verboseOutput <<< "Comment is missed in \(line)"
+			}
+
+			// Exclude comment from the rest of the line
+			if let lineRange = line.range(of: "\";")  {
+				line = line.prefix(upTo: lineRange.upperBound)
+			} else {
+				standardOutput <<< "Value in \(line) doesn’t have a terminating semicolon"
+				return nil
 			}
 
 			// Extract key and value


### PR DESCRIPTION
I encountered an issue while using AirStrings in the case when i had something like
`"random-string-key" = "visit https://www.google.com for more info" // Example entry in Localizable.strings`
It treated the double slash in the URL as it was marking the beginning of a comment.
So in order to avoid cases where there maybe an URL in the value, or in the comment afterwards I added a regular expression `\";\\s*//` that doesn't find just the first double slash, but the first double slash that is preceded with optional empty spaces and `";`